### PR TITLE
Add basic Maven project skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Maven output
+/target/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# Java-aws-enterprise
+# Java AWS Enterprise
+
+This repository contains a minimal example of a Java project targeting AWS Lambda.
+
+## Structure
+
+- `src/main/java` – application source code
+- `pom.xml` – Maven build configuration
+
+The project includes a simple Lambda handler at `com.example.lambda.HelloLambda` that returns a greeting message.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>java-aws-enterprise</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-core</artifactId>
+            <version>1.2.3</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/main/java/com/example/lambda/HelloLambda.java
+++ b/src/main/java/com/example/lambda/HelloLambda.java
@@ -1,0 +1,15 @@
+package com.example.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+/**
+ * Simple AWS Lambda handler that returns a greeting.
+ */
+public class HelloLambda implements RequestHandler<String, String> {
+    @Override
+    public String handleRequest(String input, Context context) {
+        String name = (input == null || input.isBlank()) ? "world" : input;
+        return "Hello, " + name + "!";
+    }
+}


### PR DESCRIPTION
## Summary
- initialize Maven build config for lambda project
- add sample HelloLambda handler
- document project structure

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central)*

------
https://chatgpt.com/codex/tasks/task_e_688a9524a724832eadf3e3af7eec49c0