### PR TITLE
Add JUnit tests for lambda example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# Java-aws-enterprise
+# Java AWS Lambda Example
+
+This project provides a simple AWS Lambda handler written in Java. It also demonstrates how to execute unit tests using JUnit.
+
+## Running Tests
+
+Execute the following command from the project root:
+
+```bash
+mvn test
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>java-aws-enterprise</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-core</artifactId>
+            <version>1.2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/HelloLambda.java
+++ b/src/main/java/com/example/HelloLambda.java
@@ -1,0 +1,14 @@
+package com.example;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+public class HelloLambda implements RequestHandler<String, String> {
+    @Override
+    public String handleRequest(String input, Context context) {
+        if (input == null) {
+            return "Hello, World!";
+        }
+        return "Hello, " + input + "!";
+    }
+}

--- a/src/test/java/com/example/HelloLambdaTest.java
+++ b/src/test/java/com/example/HelloLambdaTest.java
@@ -1,0 +1,21 @@
+package com.example;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HelloLambdaTest {
+    @Test
+    void testHandleRequestWithName() {
+        HelloLambda handler = new HelloLambda();
+        String result = handler.handleRequest("Codex", null);
+        assertEquals("Hello, Codex!", result);
+    }
+
+    @Test
+    void testHandleRequestWithNull() {
+        HelloLambda handler = new HelloLambda();
+        String result = handler.handleRequest(null, null);
+        assertEquals("Hello, World!", result);
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple AWS Lambda handler example
- provide JUnit tests for the handler
- document running tests in README
- include Maven build file with JUnit and AWS Lambda deps

## Testing
- `mvn test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688a942367a8832eb69a0cbd0cf38f1f